### PR TITLE
Fixed "STOP HIDING"

### DIFF
--- a/Main.bb
+++ b/Main.bb
@@ -7377,7 +7377,7 @@ Function DrawMenu()
 				EndIf	
 			ElseIf StopHidingTimer < 40
 				If KillTimer >= 0 Then 
-					StopHidingTimer = StopHidingTimer+FPSfactor
+					StopHidingTimer = StopHidingTimer+FPSfactor2
 					
 					If StopHidingTimer => 40 Then
 						PlaySound_Strict(HorrorSFX(15))


### PR DESCRIPTION
I fixed the most important mechanic you cant play scp cb without. If you will pause the game near peanut, it will after ~1 sec unpause with a horror sound and a message: "STOP HIDING"