### PR TITLE
Fix saving while in 1499

### DIFF
--- a/Data/subtitles.ini
+++ b/Data/subtitles.ini
@@ -650,7 +650,7 @@ voice=classd
 voice=pa
 1.7=<length=6.3>Mobile Task Force unit Epsilon-11, designated "Nine-Tailed Fox" has entered the facility.
 8.0=<length=9.5>All remaining survivors are advised to stay in the evacuation shelter or any other safe area until the unit has secured the facility.
-17.5=We'll start escorting personnel out when the escaped SCPs have been recontained.
+17.5=They'll start escorting personnel out when the escaped SCPs have been recontained.
 
 [SFX\Character\MTF\AnnouncAfter1.ogg]
 2.1=<voice=pa>We'd like to advise all surviving personnel, once again:

--- a/UpdateEvents.bb
+++ b/UpdateEvents.bb
@@ -8544,7 +8544,7 @@ Function UpdateEvents()
 End Function
 
 Function UpdateDimension1499()
-
+	; Saving while wearing 1499 in the PD very weird behavior, bandaid fix.
 	If NTF_1499PrevRoom\RoomTemplate\Name = "pocketdimension" Then CanSave = False
 
 	Local e.Events,n.NPCs,n2.NPCs,r.Rooms,it.Items,i%,j%,du.Dummy1499,du2.Dummy1499,temp%,scale#,x%,y%
@@ -8929,16 +8929,11 @@ Function UpdateDimension1499()
 				EndIf
 			EndIf
 			;[End Block]
-		EndIf
-		If e\EventName = "room1123"
-			If e\EventState > 0 And e\EventState < 7
-				CanSave = False
-			EndIf
-		EndIf
-		If e\EventName = "room860"
-			If e\EventState = 1.0
-				CanSave = False
-			EndIf
+		; Saving while wearing 1499 in 860 or the 1123 cutscene also causes very weird behavior, another bandaid fix.
+		ElseIf e\EventName = "room1123" And e\EventState > 0 And e\EventState < 7 Then
+			CanSave = False
+		ElseIf e\EventName = "room860" And e\EventState = 1.0 Then
+			CanSave = False
 		EndIf
 	Next
 	

--- a/UpdateEvents.bb
+++ b/UpdateEvents.bb
@@ -8544,8 +8544,6 @@ Function UpdateEvents()
 End Function
 
 Function UpdateDimension1499()
-	; Saving while wearing 1499 in the PD, 860 or the 1123 cutscene causes very weird behavior, bandaid fix.
-	If NTF_1499PrevRoom\RoomTemplate\Name = "pocketdimension" Lor NTF_1499PrevRoom\RoomTemplate\Name = "room860" Lor NTF_1499PrevRoom\RoomTemplate\Name = "room1123" Then CanSave = False
 
 	Local e.Events,n.NPCs,n2.NPCs,r.Rooms,it.Items,i%,j%,du.Dummy1499,du2.Dummy1499,temp%,scale#,x%,y%
 	
@@ -8929,6 +8927,19 @@ Function UpdateDimension1499()
 				EndIf
 			EndIf
 			;[End Block]
+		EndIf
+		If e\EventName = "pocketdimension"
+			CanSave = False
+		EndIf
+		If e\EventName = "room1123"
+			If e\EventState > 0 And e\EventState < 7
+				CanSave = False
+			EndIf
+		EndIf
+		If e\EventName = "room860"
+			If e\EventState = 1.0
+				CanSave = False
+			EndIf
 		EndIf
 	Next
 	

--- a/UpdateEvents.bb
+++ b/UpdateEvents.bb
@@ -8545,6 +8545,8 @@ End Function
 
 Function UpdateDimension1499()
 
+	If NTF_1499PrevRoom\RoomTemplate\Name = "pocketdimension" Then CanSave = False
+
 	Local e.Events,n.NPCs,n2.NPCs,r.Rooms,it.Items,i%,j%,du.Dummy1499,du2.Dummy1499,temp%,scale#,x%,y%
 	
 	For e.Events = Each Events
@@ -8927,9 +8929,6 @@ Function UpdateDimension1499()
 				EndIf
 			EndIf
 			;[End Block]
-		EndIf
-		If e\EventName = "pocketdimension"
-			CanSave = False
 		EndIf
 		If e\EventName = "room1123"
 			If e\EventState > 0 And e\EventState < 7


### PR DESCRIPTION
Fix saving while in room1123 & room860 to only disable saving while player is in the cutscene and forest respectively