### PR TITLE
fix: SCP-970 loop 60 texture swap blocked by stale HalloweenTex flag

### DIFF
--- a/UpdateEvents.bb
+++ b/UpdateEvents.bb
@@ -4638,11 +4638,9 @@ Function UpdateEvents()
 									e\room\NPC[1]=Null
 								EndIf
 							Case 60
-								If (Not HalloweenTex) Then
-									Local tex970 = LoadTexture_Strict("GFX\npcs\173h.pt", 1)
-									EntityTexture Curr173\obj, tex970, 0, 0
-									FreeTexture tex970
-								EndIf
+								Local tex970 = LoadTexture_Strict("GFX\npcs\173h.pt", 1)
+								EntityTexture Curr173\obj, tex970, 0, 0
+								FreeTexture tex970
 						End Select
 						
 						If Rand(10)=1 Then


### PR DESCRIPTION
The SCP-970 recursive hallway event at loop 60 swaps SCP-173s texture to the jack-o-lantern skin (173h.pt). This was guarded by "If (Not HalloweenTex)", which silently skipped the swap whenever the global flag was True from a previous Halloween session, or from the console "halloween" toggle. Since HalloweenTex is never serialized in save files and never explicitly reset to False outside of SCP-173s CreateNPC date check, the flag could remain stale across play sessions, permanently preventing the event. Removed the HalloweenTex guard. The texture being applied is the same 173h.pt used by Halloween, so re-applying it does no harm.